### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -2,6 +2,9 @@ name: markdownlint
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/govuk-digital-backbone/request-for-comments/security/code-scanning/1](https://github.com/govuk-digital-backbone/request-for-comments/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the workflow. Since the workflow only needs to read repository contents to lint Markdown files, the `contents: read` permission is sufficient.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
